### PR TITLE
Use "asdf install" cmd to install from .tool-versions file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,7 @@ dependencies:
     - if ! asdf | grep version; then git clone https://github.com/HashNuke/asdf.git ~/.asdf; fi
     - asdf plugin-add erlang https://github.com/HashNuke/asdf-erlang.git
     - asdf plugin-add elixir https://github.com/HashNuke/asdf-elixir.git
-    - erlang_version=$(awk '/erlang/ { print $2 }' .tool-versions) && asdf install erlang ${erlang_version}
-    - elixir_version=$(awk '/elixir/ { print $2 }' .tool-versions) && asdf install elixir ${elixir_version}
+    - asdf install
     - yes | mix deps.get
     - yes | mix local.rebar
 test:


### PR DESCRIPTION
This change uses one command to install all versions specified in the `.tool-versions` file.
