### PR TITLE
Fix documentation bugs & many enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,29 @@ end
 ```elixir
 # config/config.exs -- default
 config :email_checker,
-  default_dns: {8, 8, 8, 8},
+  default_dns: :system,
+  also_dns: [],
+  validations: [Format,MX,SMTP],
   smtp_retries: 2,
   timeout_milliseconds: :infinity
 ```
 
-We need to manually load DNS records to validate if a MX exists or not. When
-we load the library Erlang doesn't have its DNS record list yet. So to avoid
-any problem, we define a default DNS. By default the value is : `{8,8,8,8}`, which
-is Google's primary public DNS server. Please note that the IP address is
-represented as a tuple separated by commas.
+In the test environment, we need to manually load DNS records to validate if an
+MX exists or not. When we load the library Erlang doesn't have its DNS record
+list yet. So to avoid any problem, we define a default DNS. By default the value
+for the test environment is : `{8,8,8,8}`, which is Google's primary public
+DNS server. If you find that you have odd failures in name resolution, you may
+have to specify a default DNS server.
+
+In the case you need to load more DNS servers manually after the default one, you
+can set a list of more DNS server IPs in the `also_dns` setting.
+
+Please note that the IP address is represented as a tuple separated by commas.
+
+The default validations setting should be suitable for most cases. If you use
+fake but valid-looking email addresses in your own tests, you may need to set
+the validations to just `[Format]`, and MX and SMTP testing will then not be
+used in that configuration.
 
 The SMTP validation strategy will attempt 2 retries, by default.
 
@@ -67,7 +80,7 @@ milliseconds. Please note that:
 ```elixir
 # config/config.exs -- example personalized configuration
 config :email_checker,
-  default_dns: {4, 2, 2, 1},
+  default_dns: {8, 8, 8, 8},
   smtp_retries: 1,
   timeout_milliseconds: 6000
 ```

--- a/README.md
+++ b/README.md
@@ -38,16 +38,38 @@ end
 
 ### Configuration
 
+```elixir
+# config/config.exs -- default
+config :email_checker,
+  default_dns: {8, 8, 8, 8},
+  smtp_retries: 2,
+  timeout_milliseconds: :infinity
+```
+
 We need to manually load DNS records to validate if a MX exists or not. When
 we load the library Erlang doesn't have its DNS record list yet. So to avoid
-any problem, we define a default DNS. By default the value is : `4,2,2,1` (note
-that tuples are separated by commas).
+any problem, we define a default DNS. By default the value is : `{8,8,8,8}`, which
+is Google's primary public DNS server. Please note that the IP address is
+represented as a tuple separated by commas.
 
-You can easily override this value:
+The SMTP validation strategy will attempt 2 retries, by default.
+
+The MX and SMTP validation strategies, each in their own way, use the same
+default timeout for net connections as the underlying Erlang library calls. It
+is important to note that this value is `:infinity`, and the call will take as
+long as the call takes. You likely want to set to a sensible timeout in
+milliseconds. Please note that:
+
+ * For the MX validation, this is the timeout of the call to the DNS server for
+   MX records.
+ * For the SMTP validation, the timeout is divided by the number of retries.
 
 ```elixir
-# config/config.exs
-config :email_checker, default_dns: {4,2,2,1}
+# config/config.exs -- example personalized configuration
+config :email_checker,
+  default_dns: {4, 2, 2, 1},
+  smtp_retries: 1,
+  timeout_milliseconds: 6000
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ all emails using this domain seems valid even if they are not.
 # mix.exs
 def application do
   [mod: {YourModule, []},
-   applications: [..., email_checker, ...]
+   applications: [
+     # other applications...
+     :email_checker,
+     # other applications...
+     ]
   ]
 end
 
 def deps do
   [
-    # otherdependecies...
-    {:email_checker, "~> 0.0.2"}
+    # other dependencies...
+    {:email_checker, "~> 0.0.3"}
     # other dependencies...
   ]
 end
@@ -36,13 +40,14 @@ end
 
 We need to manually load DNS records to validate if a MX exists or not. When
 we load the library Erlang doesn't have its DNS record list yet. So to avoid
-any problem, we define a default DNS. By default the value is : `4.2.2.1`.
+any problem, we define a default DNS. By default the value is : `4,2,2,1` (note
+that tuples are separated by commas).
 
-You can easily overide this value:
+You can easily override this value:
 
 ```elixir
 # config/config.exs
-config: :email_checker, default_dns: {4.2.2.1}
+config :email_checker, default_dns: {4,2,2,1}
 ```
 
 ### Usage

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,21 @@ use Mix.Config
 #       format: "$date $time [$level] $metadata$message\n",
 #       metadata: [:user_id]
 
-config :email_checker, default_dns: {4, 2, 2, 1}
+## email_checker
+# default_dns, {non_neg_integer,non_neg_integer,non_neg_integer,non_neg_integer}
+#  * This sets which DNS server to use by default
+#  * default: {8,8,8,8} - 8.8.8.8 is Google's primary public DNS server
+# smtp_retries, non_neg_integer
+#  * Maximum amount of retries to use during the SMTP validation strategy execution
+#  * default: 2
+# timeout_milliseconds, :infinity | non_neg_integer
+#  * Maximum amount of time to use during MX or SMTP validation strategy executions
+#  * timeout as non_neg_integer is in **milliseconds**
+#  * default: :infinity
+config :email_checker,
+  default_dns: {8, 8, 8, 8},
+  smtp_retries: 2,
+  timeout_milliseconds: :infinity
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,9 +16,15 @@ use Mix.Config
 #       metadata: [:user_id]
 
 ## email_checker
-# default_dns, {non_neg_integer,non_neg_integer,non_neg_integer,non_neg_integer}
+# default_dns, :system_default | {non_neg_integer,non_neg_integer,non_neg_integer,non_neg_integer}
 #  * This sets which DNS server to use by default
-#  * default: {8,8,8,8} - 8.8.8.8 is Google's primary public DNS server
+#  * default: :system_default (uses whatever is configured by default on the system)
+# also_dns, [] | [{non_neg_integer,non_neg_integer,non_neg_integer,non_neg_integer}]
+#  * This adds DNS servers to also check for name resolution
+#  * default: []
+# validations
+#  * This allows a developer to constrain the validations that are run globally to a limited subset
+#  * default: [Format,MX,SMTP]
 # smtp_retries, non_neg_integer
 #  * Maximum amount of retries to use during the SMTP validation strategy execution
 #  * default: 2
@@ -27,7 +33,9 @@ use Mix.Config
 #  * timeout as non_neg_integer is in **milliseconds**
 #  * default: :infinity
 config :email_checker,
-  default_dns: {8, 8, 8, 8},
+  default_dns: :system,
+  also_dns: [],
+  validatons: [Format,MX,SMTP],
   smtp_retries: 2,
   timeout_milliseconds: :infinity
 
@@ -36,5 +44,5 @@ config :email_checker,
 # by uncommenting the line below and defining dev.exs, test.exs and such.
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+# just a placeholder

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+# just a placeholder

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,12 @@
+use Mix.Config
+
+# We need to configure the DNS servers in the test environment, because the
+# test system loads and runs so quickly, that the DNs subsystem hasn't quite come
+# up yet.
+
+config :email_checker,
+  default_dns: {8,8,8,8},
+  also_dns: [{8,8,4,4}],
+  validatons: [Format,MX,SMTP],
+  smtp_retries: 2,
+  timeout_milliseconds: :infinity

--- a/lib/email_checker.ex
+++ b/lib/email_checker.ex
@@ -1,23 +1,18 @@
 defmodule EmailChecker do
-  @validations [
-    &EmailChecker.Format.valid?/1,
-    &EmailChecker.MX.valid?/1,
-    &EmailChecker.SMTP.valid?/1,
-  ]
+
+  defp validations do
+    strategies = Application.get_env(:email_checker, :validations, [Format,MX,SMTP])
+    for v <- strategies, do: &Module.concat(EmailChecker,v).valid?/1
+  end
 
   def valid?(email) do
     expected_length =
       validations |> length
 
     case validations |> Stream.take_while(&( &1.(email) )) |> Enum.to_list do
-      list when length(list) == expected_length ->
-        true
-      _ ->
-        false
+      list when length(list) == expected_length -> true
+      _ ->                                         false
     end
   end
 
-  defp validations do
-    @validations
-  end
 end

--- a/lib/email_checker/loader.ex
+++ b/lib/email_checker/loader.ex
@@ -2,7 +2,7 @@ defmodule EmailChecker.Loader do
   use Application
 
   def default_dns do
-    Application.get_env(:email_checker, :default_dns) || {4, 2, 2, 1}
+    Application.get_env(:email_checker, :default_dns, {8,8,8,8})
   end
 
   def start(_type, _args) do
@@ -10,7 +10,7 @@ defmodule EmailChecker.Loader do
 
     # HACK: add default DNS when `inet_db` is not yet available
     # http://stackoverflow.com/questions/33811899/elixir-errors-using-inet-res-library?noredirect=1#comment55418047_33811899
-    :inet_db.add_ns(default_dns)
+    :ok = :inet_db.add_ns(default_dns)
 
     Supervisor.start_link([], strategy: :one_for_one, name: :email_checker)
   end

--- a/lib/email_checker/loader.ex
+++ b/lib/email_checker/loader.ex
@@ -1,16 +1,37 @@
 defmodule EmailChecker.Loader do
   use Application
 
-  def default_dns do
-    Application.get_env(:email_checker, :default_dns, {8,8,8,8})
+  defp default_dns do
+    Application.get_env(:email_checker, :default_dns, :system)
+  end
+
+  defp also_dns do
+    Application.get_env(:email_checker, :also_dns, [])
+  end
+
+  defp insert_ns(ns = {w,x,y,z})
+    when is_integer(w) and is_integer(x) and is_integer(y) and is_integer(z)
+  do
+    # HACK: add a default and "also" DNS when `inet_db` is not yet available
+    # http://stackoverflow.com/questions/33811899/elixir-errors-using-inet-res-library?noredirect=1#comment55418047_33811899
+
+    # Insert the specified dns server at the head of the nameserver list
+    :ok = :inet_db.ins_ns(ns)
+  end
+
+  defp append_ns(ns = {w,x,y,z})
+    when is_integer(w) and is_integer(x) and is_integer(y) and is_integer(z)
+  do
+    # Append the specified dns server at the end of the nameserver list
+    :ok = :inet_db.add_ns(ns)
   end
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # HACK: add default DNS when `inet_db` is not yet available
-    # http://stackoverflow.com/questions/33811899/elixir-errors-using-inet-res-library?noredirect=1#comment55418047_33811899
-    :ok = :inet_db.add_ns(default_dns)
+    unless default_dns == :system, do: insert_ns(default_dns)
+
+    if is_list(also_dns), do: Enum.each(also_dns, &append_ns/1)
 
     Supervisor.start_link([], strategy: :one_for_one, name: :email_checker)
   end

--- a/lib/email_checker/mx.ex
+++ b/lib/email_checker/mx.ex
@@ -1,4 +1,7 @@
 defmodule EmailChecker.MX do
+
+  defp max_timeout(), do: Application.get_env(:email_checker, :timeout_milliseconds, :infinity)
+
   def valid?(email) do
     email
     |> EmailChecker.Tools.domain_name
@@ -18,7 +21,7 @@ defmodule EmailChecker.MX do
   defp lookup_all(domain_name) do
     domain_name
     |> String.to_char_list
-    |> :inet_res.lookup(:in, :mx)
+    |> :inet_res.lookup(:in, :mx, [], max_timeout)
     |> normalize_mx_records_to_string
   end
 

--- a/lib/email_checker/smtp.ex
+++ b/lib/email_checker/smtp.ex
@@ -1,9 +1,13 @@
 defmodule EmailChecker.SMTP do
+
+  defp max_retries(), do: Application.get_env(:email_checker, :smtp_retries, 2)
+  defp max_timeout(), do: Application.get_env(:email_checker, :timeout_milliseconds, :infinity)
+
   def valid?(email) do
-    valid?(email, 2)
+    valid?(email, max_retries)
   end
 
-  defp valid?(email, retries) when retries == 0 do
+  defp valid?(_email, retries) when retries == 0 do
     false
   end
   defp valid?(email, retries) do
@@ -26,11 +30,19 @@ defmodule EmailChecker.SMTP do
     |> EmailChecker.MX.lookup
   end
 
+  defp timeout_opt() do
+    case max_timeout do
+      :infinity            -> :infinity
+      t when is_integer(t) -> t |> div(max_retries) |> abs
+    end
+  end
+
   def smtp_reply(email) do
+    opts = [packet: :line, timeout: timeout_opt]
     socket =
       email
       |> mx_address
-      |> Socket.TCP.connect!(25, packet: :line)
+      |> Socket.TCP.connect!(25, opts)
     socket |> Socket.Stream.recv!
 
     socket |> Socket.Stream.send!("HELO\r\n")

--- a/test/email_checker/timeout_test.exs
+++ b/test/email_checker/timeout_test.exs
@@ -1,0 +1,67 @@
+defmodule EmailChecker.TimeoutTest do
+  use ExUnit.Case, async: false
+
+  # start/stop timer strategy ported from Erlang lib/kernel/src/inet.erl
+  @spec stop_timer(nil) :: true
+  @spec stop_timer(reference) :: boolean
+  @spec start_timer(:infinity) :: nil
+  @spec start_timer(non_neg_integer) :: reference
+
+  defp start_timer(:infinity), do: nil
+  defp start_timer(timeout), do: :erlang.start_timer(timeout, self, :tooslow)
+
+  defp stop_timer(nil), do: true
+  defp stop_timer(timer) do
+    case :erlang.cancel_timer(timer) do
+      false ->
+        # false, if the timer was unable to be canceled
+        receive do
+          {:timeout,_timer,_msg} -> false
+  	    after
+          0 -> false
+  	    end
+      _ ->
+        # true, if the timer was able to be canceled
+        true
+    end
+  end
+
+  test "timeout: :infinity works for known good email address and servers" do
+    timeout = :infinity
+    Application.put_env(:email_checker, :timeout_milliseconds, timeout)
+    Application.put_env(:email_checker, :smtp_retries, 1)
+
+    timer = start_timer(timeout)
+    result = EmailChecker.valid? "kevin@disneur.me"
+    timer_not_fired = stop_timer(timer)
+
+    assert timer_not_fired
+    assert result
+  end
+
+  test "timeout: non_neg_integer works for known good email address and servers" do
+    timeout = 5000
+    Application.put_env(:email_checker, :timeout_milliseconds, timeout)
+    Application.put_env(:email_checker, :smtp_retries, 1)
+
+    timer = start_timer(timeout)
+    result = EmailChecker.valid? "kevin@disneur.me"
+    timer_not_fired = stop_timer(timer)
+
+    assert timer_not_fired
+    assert result
+  end
+
+  test "timeout: non_neg_integer works to quickly return from checking a known bad email address or server" do
+    timeout = 5000
+    Application.put_env(:email_checker, :timeout_milliseconds, timeout)
+    Application.put_env(:email_checker, :smtp_retries, 1)
+
+    timer = start_timer(timeout)
+    _ = EmailChecker.valid? "derp@asdf.com"
+    timer_not_fired = stop_timer(timer)
+
+    assert !timer_not_fired
+  end
+
+end

--- a/test/email_checker/timeout_test.exs
+++ b/test/email_checker/timeout_test.exs
@@ -1,6 +1,10 @@
 defmodule EmailChecker.TimeoutTest do
   use ExUnit.Case, async: false
 
+  setup do
+   EmailChecker.TestEnv.setup_default_application_env
+  end
+
   # start/stop timer strategy ported from Erlang lib/kernel/src/inet.erl
   @spec stop_timer(nil) :: true
   @spec stop_timer(reference) :: boolean

--- a/test/email_checker_test.exs
+++ b/test/email_checker_test.exs
@@ -1,5 +1,9 @@
 defmodule EmailCheckerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+
+  setup do
+   EmailChecker.TestEnv.setup_default_application_env
+  end
 
   test "valid?: an invalid email format returns false" do
     assert false == EmailChecker.valid?("invalid-email")
@@ -15,5 +19,10 @@ defmodule EmailCheckerTest do
 
   test "valid?: an existing email address returns true" do
     assert true == EmailChecker.valid?("kevin@disneur.me")
+  end
+
+  test "valid?: a known bad email only validated only for format as configured" do
+    Application.put_env(:email_checker, :validations, [Format])
+    assert true == EmailChecker.valid?("derp@asdf.com")
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,20 @@
+defmodule EmailChecker.TestEnv do
+
+  def setup_default_application_env do
+
+    # Deviate from the default of :system here, since tests load and run so
+    # quickly, that a specific DNS server being inserted is practically required.
+    Application.put_env(:email_checker, :default_dns, {8,8,8,8})
+    Application.put_env(:email_checker, :also_dns, [{8,8,4,4}])
+
+    Application.put_env(:email_checker, :validations, [Format,MX,SMTP])
+
+    Application.put_env(:email_checker, :smtp_retries, 2)
+    Application.put_env(:email_checker, :timeout_milliseconds, :infinity)
+
+    :ok
+  end
+
+end
+
 ExUnit.start()


### PR DESCRIPTION
# Round 1 was this:
- applications:
  - email_checker was not an atom as :email_checker
  - formatting like deps section
- deps:
  - bump version to latest tagged version
- Configuration:
  - config macro had an erroneous trailing `:`
  - IP address for DNS in tuple was separated with dots, not commas
  - Added a note reflecting the above
# Round 2 was when I needed it to fail faster for bad emails/servers:

Add support for timeouts (and tests); add configurable smtp retries and timeouts; change default DNS server to more obviously public one
## config.exs
### Configure options  for email_checker
- default_dns -- set to Google's primary public DNS server 8.8.8.8, and documented as such.
- smtp_retries - 2 still default, but now configurable
- timeout_milliseconds -- timeout to use for MX and SMTP validation strategies (so, coupled with smtp_retries, this isn't about how much latency may occur overall in single call to `valid?`, but how long each strategy has to use internet activities that may take very long)
## loader.ex

Use new default Google's public DNS server
### inet_db.add_ns

I was curious about this too, and looked into it. Painfully, looks like the generated docs/man-page for inet_db was removed in R18. I felt it was good to match or explode on the result being as expected (:ok), since missing this is effectively a program error -- i.e. if the default_dns is configured, this call had better succeed
## mx.ex

Use timeout_miliseconds.
## smtp.ex

Use timeout_miliseconds, and spread that total over the entire validation.
## timeout_test.exs
- 2 tests for a known good email and server, with :infinity and 5000 ms timeouts
- 1 test for a known bad email/server with a 5000 ms timeout to assert it it ending sooner than :infinity
## README.md

Documentation related to the new timeout and retry configuration options
# Round 3

Add configurable validators; add supplemental DNS servers
- Allows the user to configure which validations are loaded by default by the library. This is very useful in test environments, where only Format can be set, and then good and bad emails can be easily made -- e.g. good@fake.com, bad@sobad
- Cleaned up the DNS loader a bit, and added supplemental "also" dns servers.
- Cleaned up the tests a bit. Since some of the new tests change the app environemnt, it was helpful to add a function available to all test suites to reset the environment.
- Also, made sure that the new test env actually sets a DNS server to avoid the weird early-DNS erlang vm issue.
